### PR TITLE
Migrate from SQLSERVER to POSTGRESQL

### DIFF
--- a/DiemEcommerce.API/Program.cs
+++ b/DiemEcommerce.API/Program.cs
@@ -58,8 +58,7 @@ builder.Services.Configure<FormOptions>(options =>
 
 // Configure Options and SQL => Remember mapcarter
 builder.Services.AddInterceptorPersistence();
-builder.Services.ConfigureSqlServerRetryOptionsPersistence(builder.Configuration.GetSection(nameof(SqlServerRetryOptions)));
-builder.Services.AddSqlServerPersistence();
+builder.Services.AddPostgreSqlPersistence();
 builder.Services.AddRepositoryPersistence();
 
 builder.Services.AddJwtAuthenticationApi(builder.Configuration);

--- a/DiemEcommerce.Persistence/DependencyInjection/Extensions/ServiceCollectionExtensions.cs
+++ b/DiemEcommerce.Persistence/DependencyInjection/Extensions/ServiceCollectionExtensions.cs
@@ -1,39 +1,31 @@
 using DiemEcommerce.Domain.Abstractions.Repositories;
-using DiemEcommerce.Persistence.DependencyInjection.Options;
 using DiemEcommerce.Persistence.Interceptors;
 using DiemEcommerce.Persistence.Repositories;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Options;
 
 namespace DiemEcommerce.Persistence.DependencyInjection.Extensions;
 
 public static class ServiceCollectionExtensions
 {
-    public static void AddSqlServerPersistence(this IServiceCollection services)
+    public static void AddPostgreSqlPersistence(this IServiceCollection services)
     {
         services.AddDbContextPool<ApplicationDbContext>((provider, builder) =>
         {
             var auditableInterceptor = provider.GetService<UpdateAuditableEntitiesInterceptor>()!;
             var deletableInterceptor = provider.GetService<DeleteAuditableEntitiesInterceptor>()!;
             var configuration = provider.GetRequiredService<IConfiguration>();
-            var options = provider.GetRequiredService<IOptionsMonitor<SqlServerRetryOptions>>();
 
             builder
                 .EnableDetailedErrors(true)
                 .EnableSensitiveDataLogging(true)
-                .UseLazyLoadingProxies(true) // UseLazyLoadingProxies should be enabled if navigation properties are virtual
-                .UseSqlServer(
-                    connectionString: configuration.GetConnectionString("WriteConnectionString"),
-                    sqlServerOptionsAction: optionsBuilder =>
-                        optionsBuilder.ExecutionStrategy(dependencies => new SqlServerRetryingExecutionStrategy(
-                            dependencies: dependencies,
-                            maxRetryCount: options.CurrentValue.MaxRetryCount,
-                            maxRetryDelay: options.CurrentValue.MaxRetryDelay,
-                            errorNumbersToAdd: options.CurrentValue.ErrorNumbersToAdd))
+                .UseLazyLoadingProxies(true)
+                .UseNpgsql(
+                    connectionString: configuration.GetConnectionString("MasterConnection"),
+                    npgsqlOptionsAction: optionsBuilder =>
+                        optionsBuilder
                             .MigrationsAssembly(typeof(ApplicationDbContext).Assembly.GetName().Name)
-                            .EnableRetryOnFailure()
                             .UseQuerySplittingBehavior(QuerySplittingBehavior.SplitQuery)
                 )
                 .AddInterceptors(auditableInterceptor, deletableInterceptor);
@@ -42,27 +34,20 @@ public static class ServiceCollectionExtensions
         services.AddDbContextPool<ApplicationReplicateDbContext>((provider, builder) =>
         {
             var configuration = provider.GetRequiredService<IConfiguration>();
-            var options = provider.GetRequiredService<IOptionsMonitor<SqlServerRetryOptions>>();
 
             builder
                 .EnableDetailedErrors(true)
                 .EnableSensitiveDataLogging(true)
-                .UseLazyLoadingProxies(true) // UseLazyLoadingProxies should be enabled if navigation properties are virtual
-                .UseSqlServer(
-                    connectionString: configuration.GetConnectionString("ReadConnectionString"),
-                    sqlServerOptionsAction: optionsBuilder =>
-                        optionsBuilder.ExecutionStrategy(dependencies => new SqlServerRetryingExecutionStrategy(
-                            dependencies: dependencies,
-                            maxRetryCount: options.CurrentValue.MaxRetryCount,
-                            maxRetryDelay: options.CurrentValue.MaxRetryDelay,
-                            errorNumbersToAdd: options.CurrentValue.ErrorNumbersToAdd))
+                .UseLazyLoadingProxies(true)
+                .UseNpgsql(
+                    connectionString: configuration.GetConnectionString("SlaveConnection"),
+                    npgsqlOptionsAction: optionsBuilder =>
+                        optionsBuilder
                             .MigrationsAssembly(typeof(ApplicationReplicateDbContext).Assembly.GetName().Name)
-                            .EnableRetryOnFailure()
                             .UseQuerySplittingBehavior(QuerySplittingBehavior.SplitQuery)
                 );
         });
     }
-
 
     public static void AddInterceptorPersistence(this IServiceCollection services)
     {
@@ -74,11 +59,4 @@ public static class ServiceCollectionExtensions
     {
         services.AddTransient(typeof(IRepositoryBase<,,>), typeof(RepositoryBase<,,>));
     }
-    
-    public static OptionsBuilder<SqlServerRetryOptions> ConfigureSqlServerRetryOptionsPersistence(this IServiceCollection services, IConfigurationSection section)
-        => services
-            .AddOptions<SqlServerRetryOptions>()
-            .Bind(section)
-            .ValidateDataAnnotations()
-            .ValidateOnStart();
 }

--- a/DiemEcommerce.Persistence/DependencyInjection/Options/PostgresRetryOptions.cs
+++ b/DiemEcommerce.Persistence/DependencyInjection/Options/PostgresRetryOptions.cs
@@ -2,9 +2,9 @@ using System.ComponentModel.DataAnnotations;
 
 namespace DiemEcommerce.Persistence.DependencyInjection.Options;
 
-public record SqlServerRetryOptions
+public record PostgresRetryOptions
 {
     [Required, Range(5, 20)] public int MaxRetryCount { get; init; }
     [Required, Timestamp] public TimeSpan MaxRetryDelay { get; init; }
-    public int[]? ErrorNumbersToAdd { get; init; }
+    public string[]? ErrorCodesToAdd { get; init; }
 }

--- a/DiemEcommerce.Persistence/DiemEcommerce.Persistence.csproj
+++ b/DiemEcommerce.Persistence/DiemEcommerce.Persistence.csproj
@@ -13,11 +13,11 @@
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>
       <PackageReference Include="Microsoft.EntityFrameworkCore.Proxies" Version="8.0.7" />
-      <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.7" />
       <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
       <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
       <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
       <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="8.0.0" />
+      <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -100,9 +100,6 @@ services:
       CloudinaryOptions__CloudName: ${CLOUDINARY_CLOUD_NAME}
       CloudinaryOptions__ApiKey: ${CLOUDINARY_API_KEY}
       CloudinaryOptions__ApiSecret: ${CLOUDINARY_API_SECRET}
-      # Update retry options for PostgreSQL
-      PostgresRetryOptions__MaxRetryCount: ${POSTGRESRETRYOPTIONS_MAXRETRYCOUNT:-5}
-      PostgresRetryOptions__MaxRetryDelay: ${POSTGRESRETRYOPTIONS_MAXRETRYDELAY:-30}
       AllowedHosts: "*"
     networks:
       - diem-ecommerce-network


### PR DESCRIPTION
This pull request transitions the persistence layer of the `DiemEcommerce` application from SQL Server to PostgreSQL. It includes updates to dependency injection, retry strategies, and configuration files to support the new database. The most significant changes are grouped below by theme.

### Migration to PostgreSQL:
* Replaced SQL Server persistence setup with PostgreSQL in `Program.cs` by removing `AddSqlServerPersistence` and adding `AddPostgreSqlPersistence`. (`[DiemEcommerce.API/Program.csL61-R61](diffhunk://#diff-54a49399b265a835c69e7dcf2e8629b181668751d7b8f5b4bb60473ed8dce303L61-R61)`)
* Updated `AddPostgreSqlPersistence` method in `ServiceCollectionExtensions.cs` to use PostgreSQL-specific configurations, including `UseNpgsql` with connection strings for master and slave databases. (`[[1]](diffhunk://#diff-dcd64df6ac57c653c3b8aa7745c3528dec87c079a3e849909996f3bcaf5935a8L2-L36)`, `[[2]](diffhunk://#diff-dcd64df6ac57c653c3b8aa7745c3528dec87c079a3e849909996f3bcaf5935a8L45-L66)`)
* Removed SQL Server retry options configuration and replaced `SqlServerRetryOptions` with `PostgresRetryOptions`, which uses PostgreSQL-specific properties like `ErrorCodesToAdd`. (`[[1]](diffhunk://#diff-dcd64df6ac57c653c3b8aa7745c3528dec87c079a3e849909996f3bcaf5935a8L77-L83)`, `[[2]](diffhunk://#diff-a0aaa5c557106c78cd9c60505cab38839af83895590c76b366231ba63e7d585bL5-R9)`)

### Code cleanup and resiliency improvements:
* Simplified the transaction handling in `TransactionPipelineBehavior.cs` by removing the SQL Server execution strategy and adding explicit rollback handling with cancellation tokens. (`[DiemEcommerce.Application/Behaviors/TransactionPipelineBehavior.csL24-R35](diffhunk://#diff-976049d6928fe9b8e75599948fb7d38d7388b65448233e5e8276dc37ac0e20e9L24-R35)`)
* Removed unused imports and redundant code related to SQL Server, such as `Microsoft.EntityFrameworkCore` references and retry options. (`[[1]](diffhunk://#diff-976049d6928fe9b8e75599948fb7d38d7388b65448233e5e8276dc37ac0e20e9L3)`, `[[2]](diffhunk://#diff-dcd64df6ac57c653c3b8aa7745c3528dec87c079a3e849909996f3bcaf5935a8L77-L83)`)

### Dependency and configuration updates:
* Replaced the `Microsoft.EntityFrameworkCore.SqlServer` package with `Npgsql.EntityFrameworkCore.PostgreSQL` in `DiemEcommerce.Persistence.csproj`. (`[DiemEcommerce.Persistence/DiemEcommerce.Persistence.csprojL16-R20](diffhunk://#diff-3b77e4caedbf2593ecef0645c29bddae3963b601ada8f0f9d1acc1ea736e9c6fL16-R20)`)
* Removed PostgreSQL retry options from `docker-compose.yml` as they are no longer explicitly configured in the environment. (`[docker-compose.ymlL103-L105](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L103-L105)`)